### PR TITLE
Upgrade ember concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-auto-import": "^2.4.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
-    "ember-concurrency": "^2.1.2",
+    "ember-concurrency": "^3.1.1",
     "ember-gesture-modifiers": "^4.0.1 || ^5.0.0",
     "ember-get-config": "^2.0",
     "ember-modal-dialog": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7419,7 +7419,7 @@ ember-composable-helpers@^5.0.0:
     ember-cli-babel "^7.26.3"
     resolve "^1.10.0"
 
-ember-concurrency@^2.0.0, ember-concurrency@^2.1.2:
+ember-concurrency@^2.0.0:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-2.3.7.tgz#52d786e37704b9054da1952638797e23714ec0e1"
   integrity sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==
@@ -7432,6 +7432,19 @@ ember-concurrency@^2.0.0, ember-concurrency@^2.1.2:
     ember-cli-htmlbars "^5.7.1"
     ember-compatibility-helpers "^1.2.0"
     ember-destroyable-polyfill "^2.0.2"
+
+ember-concurrency@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-3.1.1.tgz#7f55ba4bfa4f42cfb23f8cb70aa3c6ef224e9500"
+  integrity sha512-doXFYYfy1C7jez+jDDlfahTp03QdjXeSY/W3Zbnx/q3UNJ9g10Shf2d7M/HvWo/TC22eU+6dPLIpqd/6q4pR+Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/types" "^7.12.13"
+    "@glimmer/tracking" "^1.1.2"
+    ember-cli-babel "^7.26.11"
+    ember-cli-babel-plugin-helpers "^1.1.1"
+    ember-cli-htmlbars "^6.2.0"
+    ember-compatibility-helpers "^1.2.0"
 
 ember-data@^4.4.0:
   version "4.9.1"


### PR DESCRIPTION
Why?

Upgrade ember concurrency to 3.1.1